### PR TITLE
feat: display turns off after n seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ security:
     # [OPTIONAL] (text) key used to hash pin code
     key: test
 
+display:
+  # [OPTIONAL] (number) if provided, the display will turn off after n seconds have passed
+  sleep_timeout: 10
+
 touch:
   # [OPTIONAL] (bool=false|0) calibrate touch sensor if true or 1
   force_calibration: 0
@@ -126,7 +130,6 @@ touch:
 
 > [!TIP]
 > Once the boot process is finished, remove the SD card from the board, and store it somewhere safe. Before rebooting, or if you want to add new secrets, remember to put it back in the board.
-
 
 > [!WARNING]
 > Upon the initial boot, it is imperative to undergo the calibration process at least once, as outlined in the `How to build` section below.

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,6 +1,7 @@
 #include <FS.h>
 #include <SD.h>
 #include <YAMLDuino.h>
+#include <cstdlib>
 #include "constants.h"
 
 class Configuration
@@ -31,7 +32,10 @@ public:
 	{
 		bool forceCalibration = false;
 	} touch;
-
+	struct DisplaySettings
+	{
+		int sleepTimeout = 10;
+	} display;
 	static Configuration parse(const char *filePath);
 };
 
@@ -94,6 +98,21 @@ Configuration Configuration::parse(const char *filePath)
 	{
 		const char *forceCalibration = root.gettext("touch:force_calibration");
 		config.touch.forceCalibration = forceCalibration && (strcmp(forceCalibration, "true") == 0 || strcmp(forceCalibration, "1") == 0);
+	}
+
+	if (root["display"].isMap())
+	{
+		const char *sleepTimeoutStr = root.gettext("display:sleep_timeout");
+		int parsedSleepTimeout = atoi(sleepTimeoutStr);
+
+		if (parsedSleepTimeout >= 0)
+		{
+			config.display.sleepTimeout = parsedSleepTimeout;
+		}
+		else
+		{
+			config.display.sleepTimeout = 0;
+		}
 	}
 
 	return config;

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -34,7 +34,10 @@ public:
 	{
 		bool forceCalibration = false;
 	} touch;
-
+	struct DisplaySettings
+	{
+		int sleepTimeout = 0;
+	} display;
 	static Configuration parse(const char *filePath);
 };
 

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -11,7 +11,13 @@
 #include "touch.hpp"
 
 // Function declarations
-void init_display();
+void init_display(Configuration config);
 lv_disp_t *register_display();
+void turn_off_display();
+void turn_on_display();
+void reset_display_off_timer();
+void check_display_timeout();
+void display_handle_single_touch();
+void display_handle_double_touch();
 
 #endif // LVGL_DISPLAY_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -54,6 +54,8 @@ void loop()
   // NOTE: display available free memory
   print_free_memory();
 
+  display_timeout_handler();
+
   // NOTE: connect to mqtt broker and subscribe to topics
   connect_to_mqtt();
 

--- a/src/touch-screen.cpp
+++ b/src/touch-screen.cpp
@@ -2,17 +2,36 @@
 #include "display.hpp"
 #include "touch.hpp"
 
+void handle_single_touch_event()
+{
+	Serial.println("SINGLE TOUCH");
+	display_handle_single_touch();
+}
+
+void handle_double_touch_event()
+{
+	Serial.println("DOUBLE TOUCH");
+	display_handle_double_touch();
+}
+
 void init_touch_screen(Configuration config)
 {
 	Serial.printf("Initializing touch screen.");
 
-	init_touch(config);
+	init_touch(config, handle_single_touch_event, handle_double_touch_event);
 
-	init_display();
+	init_display(config);
 
 	lv_disp_t *disp = register_display();
 
 	register_touch(disp);
 
+	reset_display_off_timer();
+
 	Serial.printf("Touch screen initialized.");
+}
+
+void display_timeout_handler()
+{
+	check_display_timeout();
 }

--- a/src/touch-screen.hpp
+++ b/src/touch-screen.hpp
@@ -7,5 +7,6 @@
 #include "touch.hpp"
 
 void init_touch_screen(Configuration config);
+void display_timeout_handler();
 
 #endif // TOUCH_SCREEN

--- a/src/touch.hpp
+++ b/src/touch.hpp
@@ -8,8 +8,10 @@
 #include "constants.h"
 #include "config.hpp"
 
+typedef void (*TouchCallback)();
+
 // Function declarations
-void init_touch(Configuration config);
+void init_touch(Configuration config, TouchCallback singleTouchCallback, TouchCallback doubleTouchCallback);
 void register_touch(lv_disp_t *disp);
 
 #endif // LVGL_TOUCH_H


### PR DESCRIPTION
A new property has been added to `config.yml` to enable the display to turn off after a specified number of seconds.

```yml
display:
  # [OPTIONAL] (number) if provided, the display will turn off after n seconds have passed
  sleep_timeout: 10
```

>[!IMPORTANT]
>If sleep_timeout is ≤ 0, or omitted, the display won't turn off.


Once the display is turned off, simply touch the screen to turn it back on