### PR TITLE
Organize MFA services into groups improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,10 +169,14 @@ platformio device monitor --environment esp32-cyd
 Services are registered in a file called `services.yml` that must be located in the root of an SD card. It must follow the schema shown below:
 
 ```yml
-services: list
-  - name: text[60] Max number of characters is 60. An exception is raised when not set.
-    secret: text Length is dynamic. An exception is raised when not set.
-    group: integer [0~4] It accepts integers from 0 to 4. Default to 0 when not set, > 4 or < 0. An exception is raised when not an integer.
+# [REQUIRED] (list) stores a list of services
+services:
+  # [REQUIRED] (text) unique name for a service in a group. It must not exceed 60 characters.
+  - name: abc
+    # [REQUIRED] (text) Base32 encoded secret for the service.
+    secret: abc
+    # [OPTIONAL] (number) [default 0] it also defaults to 0 if < 0 or > 9
+    group: 0
 ```
 
 For example:
@@ -209,17 +213,19 @@ services:
 ```
 
 > [!IMPORTANT]
+> At present, you can create up to 10 groups, with each group containing up to 10 services.
+
+> [!IMPORTANT]
 > The service name must not exceed 60 characters.
 
 > [!IMPORTANT]
 > Secrets must be stored unencrypted and encoded using Base32. All MFA services I tried already provide secrets in Base32 encoding. If you find one that does not, ensure the secret is Base32 encoded before adding it to the file.
 
 > [!IMPORTANT]
-> If you don't set the "group" property, it will default to 0.
+> If you don't set the "group" property for a service, it will default to 0. Additionally, if the "group" property is less than 0 or greater than 9, it will also default to 0.
 
 > [!IMPORTANT]
 > The service name acts as a unique key within a group. If two services share the same key within the same group, the last one listed in the file will be the one used.
-
 
 ### 📚 How to verify if TOTP codes are correct
 
@@ -366,7 +372,6 @@ Instead of typing a pin code, it will be possible to unlock the board using a fi
 ### 🔜 Create chrome extension to ease registering TOTP secrets
 
 When the ESP32-MFA-Authenticator extension is enabled, a new button called "register secret" appears, in the browser's context menu, when right clicking over a QR code. When selecting this button, the registration flow starts.
-
 
 ## 💖 Become a Sponsor
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -8,8 +8,9 @@
 
 // NOTE: all totps must have a period of 30 seconds, for now
 #define TOTP_PERIOD 30
-// NOTE: max number of groups of services. At the moment, it can only parse 5 groups of 10 services
-#define MAX_NUMBER_OF_GROUPS 5
+// NOTE: this limitation is due to the YAML parser
+// NOTE: max number of groups of services.
+#define MAX_NUMBER_OF_GROUPS 10
 // NOTE: due to mem limits there has to exist a max number of services we can generate TOTPs for
 #define MAX_NUMBER_OF_SERVICES 10
 // NOTE: 60 digits + 1 for the null-terminating character

--- a/src/mfa.cpp
+++ b/src/mfa.cpp
@@ -34,7 +34,6 @@ void load_services()
   Serial.println("Reading the services file");
 
   YAMLNode root = YAMLNode::loadStream(file);
-  file.close();
 
   if (root.isNull())
   {
@@ -51,7 +50,7 @@ void load_services()
 
   if (services.isSequence())
   {
-    for (int i = 0; i < services.size(); i++)
+    for (int i = 0; i < services.size(); ++i)
     {
       YAMLNode service = services[i];
 
@@ -72,22 +71,18 @@ void load_services()
       if (!service["group"].isNull())
       {
         service_group = string_2_int(service.gettext("group"));
+        if (service_group < 0 || service_group > (MAX_NUMBER_OF_GROUPS - 1))
+        {
+          service_group = 0;
+        }
       }
 
       upsert_service_in_group_by_name(service_group, name, new_secret.length, new_secret.value);
     }
   }
-
+  file.close();
   print_all_services_groups();
   Serial.println("all services were loaded");
-}
-
-void init_mfa()
-{
-  Serial.println("Initializing mfa");
-  load_services();
-  update_totps();
-  Serial.println("MFA initialized");
 }
 
 void add_new_service(volatile uint8_t *payload, unsigned int length)

--- a/src/mfa.h
+++ b/src/mfa.h
@@ -21,7 +21,7 @@ extern "C"
 #include "file.hpp"
 #include "clock.hpp"
 #include "utils.hpp"
-void init_mfa();
+
 void add_new_service(volatile uint8_t *payload, unsigned int length);
 void load_services();
 


### PR DESCRIPTION
- increase MAX_NUMBER_OF_GROUPS to 10, after some experiments to find the max number of characters the YAML Parser was able to handle in a single file. I discovered that YAMLDuino was able to parse a file containing up to 18203 characters. After parsing and storing 113 services, each using 60 characters for the service name, and 64 characters for the secret, there was still 44740 bytes of memory available.
- move the loading of services before initializing any other module to ensure the YAML Parser has the max amount of memory available while parsing the file
- ensure group is set to 0 when configured with a value that is out of bounds