### PR TITLE
Remove the limit of services per group

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -80,6 +80,7 @@
     "stdio.h": "c",
     "touch.h": "c",
     "pin.h": "c",
-    "auth.h": "c"
+    "auth.h": "c",
+    "esp_log.h": "c"
   }
 }

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ services:
   - name: abc
     # [REQUIRED] (text) Base32 encoded secret for the service.
     secret: abc
-    # [OPTIONAL] (number) [default 0] it also defaults to 0 if < 0 or > 9
+    # [OPTIONAL] (number) [default 0] it must be an integer between 0 and 255. It is used to group services and determine their priority. Services with smaller group numbers are rendered first. For instance, services assigned to group 100 will be rendered before those in group 255. In a services file. you can have up to 150 services.
     group: 0
 ```
 
@@ -195,20 +195,7 @@ platformio device monitor
 
 ### 📚 How to register a Service
 
-Services are registered in a file called `services.yml` that must be located in the root of an SD card. It must follow the schema shown below:
-
-```yml
-# [REQUIRED] (list) stores a list of services
-services:
-  # [REQUIRED] (text) unique name for a service in a group. It must not exceed 60 characters.
-  - name: abc
-    # [REQUIRED] (text) Base32 encoded secret for the service.
-    secret: abc
-    # [OPTIONAL] (number) [default 0] it also defaults to 0 if < 0 or > 9
-    group: 0
-```
-
-For example:
+Services are registered in a file called `services.yml` that must be located in the root of an SD card. For example:
 
 ```yml
 services:
@@ -242,19 +229,19 @@ services:
 ```
 
 > [!IMPORTANT]
-> At present, you can create up to 10 groups, with each group containing up to 10 services.
+> At present, you can register up to 100 services divided across 10 groups.
 
 > [!IMPORTANT]
 > The service name must not exceed 60 characters.
 
 > [!IMPORTANT]
+> The service group must be between 0 and 255. If you don't set a value, it will default to 0.
+
+> [!IMPORTANT]
 > Secrets must be stored unencrypted and encoded using Base32. All MFA services I tried already provide secrets in Base32 encoding. If you find one that does not, ensure the secret is Base32 encoded before adding it to the file.
 
 > [!IMPORTANT]
-> If you don't set the "group" property for a service, it will default to 0. Additionally, if the "group" property is less than 0 or greater than 9, it will also default to 0.
-
-> [!IMPORTANT]
-> The service name acts as a unique key within a group. If two services share the same key within the same group, the last one listed in the file will be the one used.
+> The service name acts as a unique key within a group. If two services share the same key within the same group, the last one listed in the file will be the one used because it was the last service to be added in the db.
 
 ### 📚 How to verify if TOTP codes are correct
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -53,7 +53,7 @@ build_flags =
     -D TF_CS=5
     -D ENABLE_FAT12_SUPPORT=1
     -D LV_CONF_PATH="${PROJECT_DIR}/lv_conf.h"
-    -D CORE_DEBUG_LEVEL=4
+    -D CORE_DEBUG_LEVEL=5
     -D ENABLE_SERIAL=1
 
 [env:prod]

--- a/src/constants.h
+++ b/src/constants.h
@@ -8,11 +8,11 @@
 
 // NOTE: all totps must have a period of 30 seconds, for now
 #define TOTP_PERIOD 30
-// NOTE: this limitation is due to the YAML parser
 // NOTE: max number of groups of services.
 #define MAX_NUMBER_OF_GROUPS 10
 // NOTE: due to mem limits there has to exist a max number of services we can generate TOTPs for
-#define MAX_NUMBER_OF_SERVICES 10
+// NOTE: the YAML parser is limiting this number. It could be 150, but the parser can handle up to 113.
+#define MAX_NUMBER_OF_SERVICES 100
 // NOTE: 60 digits + 1 for the null-terminating character
 #define MAX_SERVICE_NAME_LENGTH 61
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -122,25 +122,21 @@ void loop()
 
   case TOTPS_UPDATE:
     display_timeout_handler();
-
-    if (get_active_services_group_length())
+    unsigned long elapsed_number_of_time_steps = get_elapsed_number_of_time_steps();
+    static unsigned long last_step = 0;
+    if (elapsed_number_of_time_steps != last_step)
     {
-      unsigned long elapsed_number_of_time_steps = get_elapsed_number_of_time_steps();
-      static unsigned long last_step = 0;
-      if (elapsed_number_of_time_steps != last_step)
-      {
-        update_totps();
-        ui_totp_screen_update_totp_labels();
-        last_step = elapsed_number_of_time_steps;
-      }
+      update_totps();
+      ui_totp_screen_update_totp_labels();
+      last_step = elapsed_number_of_time_steps;
+    }
 
-      int current_second = get_second();
-      static unsigned long previous_second = 0;
-      if (current_second != previous_second)
-      {
-        ui_totp_screen_update_totp_countdowns();
-        previous_second = current_second;
-      }
+    int current_second = get_second();
+    static unsigned long previous_second = 0;
+    if (current_second != previous_second)
+    {
+      ui_totp_screen_update_totp_countdowns();
+      previous_second = current_second;
     }
     break;
   }

--- a/src/services.c
+++ b/src/services.c
@@ -2,22 +2,19 @@
 
 static const char *TAG = "services";
 
-Service services_groups[MAX_NUMBER_OF_GROUPS][MAX_NUMBER_OF_SERVICES] = {0};
-int services_groups_lengths[MAX_NUMBER_OF_GROUPS] = {0};
-int active_group = 0;
+Service services[MAX_NUMBER_OF_SERVICES] = {0};
+uint8_t services_counter = 0;
+uint8_t active_group = 0;
+uint8_t groups[MAX_NUMBER_OF_GROUPS] = {-1, -1, -1, -1, -1, -1, -1, -1, -1, -1};
+uint8_t groups_counter = 0;
 
-int find_service_index_in_group_by_name(int group, const char *name)
+int find_service_index_by_name_and_group(const char *name, uint8_t group)
 {
     ESP_LOGI(TAG, "locating service %s in group %d", name, group);
-    if (group < 0 || group >= MAX_NUMBER_OF_GROUPS)
-    {
-        ESP_LOGE(TAG, "invalid group number %d", group);
-        return -1;
-    }
 
     for (int i = 0; i < MAX_NUMBER_OF_SERVICES; ++i)
     {
-        if (strcmp(services_groups[group][i].name, name) == 0)
+        if (strcmp(services[i].name, name) == 0 && services[i].group == group)
         {
             return i;
         }
@@ -27,179 +24,181 @@ int find_service_index_in_group_by_name(int group, const char *name)
     return -1;
 }
 
-bool upsert_service_in_group_by_name(int group, const char *name, int secret_length, uint8_t *secret_value)
+bool does_group_exist(uint8_t group)
+{
+    ESP_LOGI(TAG, "Checking if group %d exists", group);
+
+    for (int i = 0; i < MAX_NUMBER_OF_GROUPS; i++)
+    {
+        if (groups[i] == group)
+        {
+            ESP_LOGI(TAG, "Group %d exists", group);
+            return true;
+        }
+    }
+
+    ESP_LOGI(TAG, "Group %d does not exist", group);
+    return false;
+}
+
+bool add_group_to_list(uint8_t group)
+{
+    if (groups_counter >= MAX_NUMBER_OF_GROUPS)
+    {
+        ESP_LOGE(TAG, "Max number of groups reached. Group %d can't be added.", group);
+        return false;
+    }
+
+    int i;
+    for (i = groups_counter - 1; (i >= 0 && groups[i] > group); i--)
+    {
+        groups[i + 1] = groups[i];
+    }
+
+    groups[i + 1] = group;
+    groups_counter++;
+
+    ESP_LOGI(TAG, "Group %d added successfully. Current count: %d", group, groups_counter);
+    return true;
+}
+
+bool upsert_service_by_name_and_group(const char *name, uint8_t group, int secret_length, uint8_t *secret_value)
 {
     ESP_LOGI(TAG, "adding service %s in group %d", name, group);
-    int index = find_service_index_in_group_by_name(group, name);
+
+    if (!does_group_exist(group))
+    {
+        ESP_LOGD(TAG, "adding new group %d", group);
+        if (!add_group_to_list(group))
+        {
+            ESP_LOGD(TAG, "group not added %d", group);
+            return false;
+        }
+        ESP_LOGD(TAG, "group added %d", group);
+    }
+
+    int index = find_service_index_by_name_and_group(name, group);
     if (index == -1)
     {
-        if (services_groups_lengths[group] >= MAX_NUMBER_OF_SERVICES)
+        if (services_counter >= MAX_NUMBER_OF_SERVICES)
         {
-            ESP_LOGE(TAG, "no space available in the group");
+            ESP_LOGE(TAG, "no space available in the store");
             return false;
         }
 
         ESP_LOGD(TAG, "adding new service");
-        strcpy(services_groups[group][services_groups_lengths[group]].name, name);
-        services_groups[group][services_groups_lengths[group]].secret.length = secret_length;
-        services_groups[group][services_groups_lengths[group]].secret.value = secret_value;
-        services_groups_lengths[group]++;
+        strcpy(services[services_counter].name, name);
+        services[services_counter].group = group;
+        services[services_counter].secret.length = secret_length;
+        services[services_counter].secret.value = secret_value;
+        services_counter++;
     }
     else
     {
         ESP_LOGD(TAG, "updating service found at group %d and index %d", group, index);
-        services_groups[group][index].secret.length = secret_length;
-        services_groups[group][index].secret.value = secret_value;
+        services[index].secret.length = secret_length;
+        services[index].secret.value = secret_value;
+        services[index].group = group;
     }
 
     ESP_LOGI(TAG, "new service added successfully");
     return true;
 }
 
-bool upsert_service_totp_in_active_services_group_by_name(const char *name, char totp[])
+bool update_service_totp_in_active_services_group_by_name(const char *name, char totp[])
 {
-    ESP_LOGI(TAG, "adding totp %s for service %s", name, totp);
-    int index = find_service_index_in_group_by_name(active_group, name);
-    if (index == -1)
-    {
-        if (services_groups_lengths[active_group] >= MAX_NUMBER_OF_SERVICES)
-        {
-            ESP_LOGE(TAG, "no space available in the group");
-            return false;
-        }
-
-        ESP_LOGD(TAG, "adding new totp");
-        strcpy(services_groups[active_group][services_groups_lengths[active_group]].name, name);
-        strcpy(services_groups[active_group][services_groups_lengths[active_group]].totp, totp);
-        services_groups_lengths[active_group]++;
-    }
-    else
-    {
-        ESP_LOGD(TAG, "updating totp");
-        strcpy(services_groups[active_group][index].totp, totp);
-    }
-
-    ESP_LOGI(TAG, "totp added successfully");
+    ESP_LOGI(TAG, "updating totp %s for service %s and group %d", name, totp, active_group);
+    int index = find_service_index_by_name_and_group(name, active_group);
+    strcpy(services[index].totp, totp);
+    ESP_LOGI(TAG, "totp updated successfully");
     return true;
 }
 
-Service *get_service_in_group_by_index(int group, int index)
+void clear_all_services()
 {
-    ESP_LOGI(TAG, "finding service in group %d with index %d", group, index);
-    if (group < 0 || group >= MAX_NUMBER_OF_GROUPS)
-    {
-        ESP_LOGE(TAG, "invalid group nuumber %d", group);
-        return NULL;
-    }
-
-    if (index < 0 || index >= services_groups_lengths[group])
-    {
-        ESP_LOGE(TAG, "invalid service index %d", index);
-        return NULL;
-    }
-
-    ESP_LOGI(TAG, "service found in group %d with index %d", group, index);
-    return &services_groups[group][index];
+    memset(services, 0, sizeof(services));
 }
 
-Service *get_active_services_group()
-{
-    return services_groups[active_group];
-}
-
-int get_services_group_length(int group)
-{
-    return services_groups_lengths[group];
-}
-
-int get_active_services_group_length()
-{
-    return get_services_group_length(active_group);
-}
-
-void clear_all_services_groups()
-{
-    memset(services_groups, 0, sizeof(services_groups));
-    memset(services_groups_lengths, 0, sizeof(services_groups_lengths));
-}
-
-void clear_all_services_in_group(int group)
-{
-    ESP_LOGI(TAG, "clearing all services in group %d", group);
-    if (group < 0 || group >= MAX_NUMBER_OF_GROUPS)
-    {
-        ESP_LOGE(TAG, "invalid group %d", group);
-        return;
-    }
-
-    memset(services_groups[group], 0, sizeof(services_groups[group]));
-    services_groups_lengths[group] = 0;
-    ESP_LOGI(TAG, "all services in group %d were cleared", group);
-}
-
-void set_active_group(int group)
-{
-    active_group = group;
-}
-
-int get_active_group()
+uint8_t get_active_group()
 {
     return active_group;
 }
 
+Service *get_services()
+{
+    return services;
+}
+
 bool change_active_group_left()
 {
-    if (active_group > 0)
+    int current_index = -1;
+    for (int i = 0; i < groups_counter; ++i)
     {
-        active_group--;
+        if (groups[i] == active_group)
+        {
+            current_index = i;
+            break;
+        }
+    }
+
+    if (current_index == -1)
+    {
+        return false;
+    }
+
+    if (current_index > 0)
+    {
+        active_group = groups[current_index - 1];
         return true;
     }
+
     return false;
 }
 
 bool change_active_group_right()
 {
-    if (active_group < MAX_NUMBER_OF_GROUPS - 1)
+    int current_index = -1;
+    for (int i = 0; i < groups_counter; ++i)
     {
-        active_group++;
+        if (groups[i] == active_group)
+        {
+            current_index = i;
+            break;
+        }
+    }
+
+    if (current_index == -1)
+    {
+        return false;
+    }
+
+    if (current_index < groups_counter - 1)
+    {
+        active_group = groups[current_index + 1];
         return true;
     }
+
     return false;
 }
 
-void print_service_group(int group)
+void print_service(int index)
 {
-    if (group < 0 || group >= MAX_NUMBER_OF_GROUPS)
+    const Service *service = &services[index];
+    ESP_LOGD(TAG, "name: %s", service->name);
+    ESP_LOGD(TAG, "secret legnth: %d", service->secret.length);
+    ESP_LOGD(TAG, "secret value:");
+    for (int j = 0; j < service->secret.length; ++j)
     {
-        ESP_LOGE(TAG, "invalid group %d", group);
-        return;
+        ESP_LOGD(TAG, "%02X ", service->secret.value[j]);
     }
-
-    ESP_LOGD(TAG, "group: %d", group);
-    for (int i = 0; i < services_groups_lengths[group]; ++i)
-    {
-        const Service *service = &services_groups[group][i];
-        ESP_LOGD(TAG, "name: %s", service->name);
-        ESP_LOGD(TAG, "secret legnth: %d", service->secret.length);
-        ESP_LOGD(TAG, "secret value:");
-        for (int j = 0; j < service->secret.length; ++j)
-        {
-            ESP_LOGD(TAG, "%02X ", service->secret.value[j]);
-        }
-        ESP_LOGD(TAG, "totp: %s", service->totp);
-        ESP_LOGD(TAG, "-------------------");
-    }
+    ESP_LOGD(TAG, "totp: %s", service->totp);
+    ESP_LOGD(TAG, "-------------------");
 }
 
-void print_all_services_groups()
+void print_all_services()
 {
-    for (int group = 0; group < MAX_NUMBER_OF_GROUPS; ++group)
+    for (int i = 0; i < MAX_NUMBER_OF_SERVICES; ++i)
     {
-        print_service_group(group);
+        print_service(i);
     }
-}
-
-void print_active_services_group()
-{
-    print_service_group(active_group);
 }

--- a/src/services.h
+++ b/src/services.h
@@ -22,25 +22,19 @@ extern "C"
             int length;
             uint8_t *value;
         } secret;
+        uint8_t group;
         char totp[MAX_TOTP_LENGTH];
     } Service;
 
-    int find_service_index_in_group_by_name(int group, const char *name);
-    bool upsert_service_in_group_by_name(int group, const char *name, int secret_length, uint8_t *secret_value);
-    bool upsert_service_totp_in_active_services_group_by_name(const char *name, char totp[]);
-    Service *get_service_in_group_by_index(int group, int index);
-    Service *get_active_services_group();
-    int get_services_group_length(int group);
-    int get_active_services_group_length();
-    void clear_all_services_groups();
-    void clear_all_services_in_group(int group);
-    void set_active_group(int group);
-    int get_active_group();
+    int find_service_index_by_name_and_group(const char *name, uint8_t group);
+    bool upsert_service_by_name_and_group(const char *name, uint8_t group, int secret_length, uint8_t *secret_value);
+    bool update_service_totp_in_active_services_group_by_name(const char *name, char totp[]);
+    void clear_all_services();
+    uint8_t get_active_group();
+    Service *get_services();
     bool change_active_group_left();
     bool change_active_group_right();
-    void print_service_group(int group);
-    void print_all_services_groups();
-    void print_active_services_group();
+    void print_all_services();
 
 #ifdef __cplusplus
 }

--- a/src/ui/screens/ui_totp_screen.c
+++ b/src/ui/screens/ui_totp_screen.c
@@ -8,9 +8,12 @@
 lv_obj_t *create_totp_component(
     lv_obj_t *parent,
     const char *service,
-    const char *totp)
+    const char *totp,
+    const int index)
 {
     lv_obj_t *container = lv_obj_create(parent);
+    // NOTE: this is used to find which index of
+    container->user_data = index;
     lv_obj_set_width(container, 150);
     lv_obj_set_height(container, LV_SIZE_CONTENT);
     lv_obj_set_flex_flow(container, LV_FLEX_FLOW_COLUMN);
@@ -73,10 +76,15 @@ void ui_totp_screen_init(void)
 void ui_totp_screen_render_totp_components(void)
 {
     lv_obj_clean(ui_totp_screen);
-    for (int i = 0; i < get_active_services_group_length(); ++i)
+    Service *services = get_services();
+    uint8_t active_group = get_active_group();
+    for (int i = 0; i < MAX_NUMBER_OF_SERVICES; i++)
     {
-        Service service = get_active_services_group()[i];
-        create_totp_component(ui_totp_screen, service.name, service.totp);
+        Service *service = &services[i];
+        if (service->name[0] != '\0' && service->group == active_group)
+        {
+            create_totp_component(ui_totp_screen, service->name, service->totp, i);
+        }
     }
 }
 
@@ -121,11 +129,12 @@ void ui_totp_screen_update_totp_labels()
 {
     int index = 0;
     lv_obj_t *totp_component = lv_obj_get_child(ui_totp_screen, index);
+    Service *services = get_services();
     while (totp_component)
     {
-        Service service = get_active_services_group()[index];
+        Service *service = &services[(int)totp_component->user_data];
         lv_obj_t *totp_label = lv_obj_get_child(totp_component, 1);
-        lv_label_set_text(totp_label, service.totp);
+        lv_label_set_text(totp_label, service->totp);
         index++;
         totp_component = lv_obj_get_child(ui_totp_screen, index);
     }

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -1,5 +1,7 @@
 #include "ui.h"
 
+static const char *TAG = "ui";
+
 uint32_t LV_EVENT_SETUP_COMPLETE;
 lv_obj_t *ui_init_screen;
 lv_obj_t *ui_totp_screen;
@@ -59,6 +61,7 @@ void init_ui(
     bool display_pin_screen,
     int max_unlock_attempts)
 {
+    ESP_LOGI(TAG, "initializing ui");
     config.display_pin_screen = display_pin_screen;
     config.unlock_attempts = max_unlock_attempts;
     config.max_unlock_attempts = max_unlock_attempts;
@@ -76,6 +79,7 @@ void init_ui(
     ui_touch_calibration_screen_init();
     ui_totp_screen_init();
     ui_pin_screen_init();
+    ESP_LOGI(TAG, "ui initialized");
 }
 
 void load_first_screen()

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -1,6 +1,8 @@
 #ifndef UI_H
 #define UI_H
 
+#include <esp_log.h>
+
 #ifdef __cplusplus
 extern "C"
 {

--- a/src/ui/ui_events.c
+++ b/src/ui/ui_events.c
@@ -26,18 +26,10 @@ void on_totp_screen_gesture(lv_event_t *e)
 
     if (group_changed)
     {
-        int active_group_length = get_active_services_group_length();
-        if (!active_group_length)
-        {
-            ui_totp_screen_render_active_group_index();
-        }
-        else
-        {
-            update_totps();
-            ui_totp_screen_render_totp_components();
-            ui_totp_screen_update_totp_labels();
-            ui_totp_screen_update_totp_countdowns();
-        }
+        update_totps();
+        ui_totp_screen_render_totp_components();
+        ui_totp_screen_update_totp_labels();
+        ui_totp_screen_update_totp_countdowns();
     }
 }
 


### PR DESCRIPTION
It is now possible to register up to 100 services divided across 10 priority groups, instead of having a fixed amount of services per group. Users can have a single group containing 100 services, or 10 groups containing 10 services each. The amount of services rendered in a group is dynamic. The only 2 constraints are MAX_NUMBER_OF_SERVICES = 100 and MAX_NUMBER_OF_GROUPS = 10. The group property works as priority, and this means that services with smaller groups are rendered first.