### PR TITLE
Enable encryption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ config.yml
 out
 data
 *.pem
+services.yml

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -81,6 +81,11 @@
     "touch.h": "c",
     "pin.h": "c",
     "auth.h": "c",
-    "esp_log.h": "c"
+    "esp_log.h": "c",
+    "ui.h": "c",
+    "entropy.h": "c",
+    "ctr_drbg.h": "c",
+    "encryption.hpp": "c",
+    "spiffs.h": "c"
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -86,6 +86,8 @@
     "entropy.h": "c",
     "ctr_drbg.h": "c",
     "encryption.hpp": "c",
-    "spiffs.h": "c"
+    "spiffs.h": "c",
+    "config.hpp": "c",
+    "base32.h": "c"
   }
 }

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ You can flash your ESP32-CYD board with the latest build using this [site](https
 | vscode                           | >= v1.87  |
 | platform.io ide vscode extension | >= v3.3   |
 | docker                           | >= v25.0  |
+| yq                               | >= 4.45.1 |
+| openssl                          | >= 3.4.0  |
 
 > [!IMPORTANT]
 > Don't forget to install a [driver to allow your OS to recognize esp32](https://www.silabs.com/developers/usb-to-uart-bridge-vcp-drivers)
@@ -245,6 +247,22 @@ services:
 
 > [!IMPORTANT]
 > The service name acts as a unique key within a group. If two services share the same key within the same group, the last one listed in the file will be the one used because it was the last service to be added in the db.
+
+### 📚 How to encrypt/decrypt services secrets
+
+```bash
+./scripts/encrypt-services.sh --file services.yml --password $PASSWORD --salt $SALT
+./scripts/decrypt-services.sh --file services.yml --password $PASSWORD --salt $SALT
+```
+
+> [!IMPORTANT]
+> Before running any of the scripts, you must have `openssl` and `yq` installed.
+
+> [!IMPORTANT]
+> The password used is the same as the one provided during the initial setup, when the board is first booted. It must not be stored in the sd card.
+
+> [!IMPORTANT]
+> The salt is stored in the config.yml file and is generated during the initial setup, when the board is first booted.
 
 ### 📚 How to verify if TOTP codes are correct
 

--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ wifi:
 
 # [REQUIRED] used while generating a strong encryption key which will be used to encrypt the secrets of all added services
 encryption:
-  # [REQUIRED] (text) the secret must be strong and at least 8 characters long. When transferring your services to another board, you can recover the encryption key by entering the same password during the setup phase, provided the salt in your config.yml file remains unchanged. Note that the password will never be stored on the board for security purposes
-  salt: TUwNzIxF5lJncAJVMkmb4EiSP9vm0OyF
+  # [REQUIRED] (text) the salt is a Base32 encoded string and it is created automatically while creating the encryption key. When transferring your services to another board, you can recover the encryption key by entering the same password during the setup phase, provided the salt in your config.yml file remains unchanged. Note that the password will never be stored on the board for security purposes
+  salt: JBSWY3DPFQQEEYLTMUZTEII=
 
 # [REQUIRED] configure authentication for the board
 authentication:

--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ wifi:
   # [REQUIRED] (text) wifi id
   ssid: test
 
+# [REQUIRED] used while generating a strong encryption key which will be used to encrypt the secrets of all added services
+encryption:
+  # [REQUIRED] (text) the secret must be strong and at least 8 characters long. When transferring your services to another board, you can recover the encryption key by entering the same password during the setup phase, provided the salt in your config.yml file remains unchanged. Note that the password will never be stored on the board for security purposes
+  salt: TUwNzIxF5lJncAJVMkmb4EiSP9vm0OyF
+
 # [REQUIRED] configure authentication for the board
 authentication:
   # [OPTIONAL] (number) [default 3] board is locked and requires a hard reset, after N wrong unlock attempts

--- a/lv_conf.h
+++ b/lv_conf.h
@@ -518,9 +518,9 @@
 /*-----------
  * Widgets
  *----------*/
-#define LV_USE_ANIMIMG    1
+#define LV_USE_ANIMIMG    0
 
-#define LV_USE_CALENDAR   1
+#define LV_USE_CALENDAR   0
 #if LV_USE_CALENDAR
     #define LV_CALENDAR_WEEK_STARTS_MONDAY 0
     #if LV_CALENDAR_WEEK_STARTS_MONDAY
@@ -534,39 +534,39 @@
     #define LV_USE_CALENDAR_HEADER_DROPDOWN 1
 #endif  /*LV_USE_CALENDAR*/
 
-#define LV_USE_CHART      1
+#define LV_USE_CHART      0
 
-#define LV_USE_COLORWHEEL 1
+#define LV_USE_COLORWHEEL 0
 
-#define LV_USE_IMGBTN     1
+#define LV_USE_IMGBTN     0
 
 #define LV_USE_KEYBOARD   1
 
-#define LV_USE_LED        1
+#define LV_USE_LED        0
 
-#define LV_USE_LIST       1
+#define LV_USE_LIST       0
 
-#define LV_USE_MENU       1
+#define LV_USE_MENU       0
 
-#define LV_USE_METER      1
+#define LV_USE_METER      0
 
 #define LV_USE_MSGBOX     1
 
-#define LV_USE_SPAN       1
+#define LV_USE_SPAN       0
 #if LV_USE_SPAN
     /*A line text can contain maximum num of span descriptor */
     #define LV_SPAN_SNIPPET_STACK_SIZE 64
 #endif
 
-#define LV_USE_SPINBOX    1
+#define LV_USE_SPINBOX    0
 
-#define LV_USE_SPINNER    1
+#define LV_USE_SPINNER    0
 
-#define LV_USE_TABVIEW    1
+#define LV_USE_TABVIEW    0
 
-#define LV_USE_TILEVIEW   1
+#define LV_USE_TILEVIEW   0
 
-#define LV_USE_WIN        1
+#define LV_USE_WIN        0
 
 /*-----------
  * Themes

--- a/platformio.ini
+++ b/platformio.ini
@@ -25,7 +25,7 @@ lib_deps =
     https://github.com/NetRat/Base32.git#1c65e655360882074f33837ae53f777aee88418e
     https://github.com/fbiego/ESP32Time.git#cefc6857b583ae5478000da897c838a6bf6d3275
     https://github.com/bblanchon/ArduinoJson.git#v7.0.4
-    https://github.com/Mbed-TLS/mbedtls#mbedtls-2.16.0
+    
     https://github.com/tobozo/YAMLDuino.git#v1.4.0
     https://github.com/mathieucarbou/ESPAsyncWebServer.git#abcd2df5e087ef712cb7e5145a60812c473423f4
 build_flags =

--- a/scripts/decrypt-services.sh
+++ b/scripts/decrypt-services.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+set -e
+BASE_DIR=$(pwd)
+
+# NOTE: validate binary dependencies are installed
+if ! command -v openssl &>/dev/null; then
+  echo "Error: openssl is required but not installed. Please, refer to https://github.com/openssl/openssl" >&2
+  exit 1
+fi
+
+if ! command -v yq &>/dev/null; then
+  echo "Error: yq is required but not installed. Please, refer to https://github.com/mikefarah/yq" >&2
+  exit 1
+fi
+
+password=""
+salt=""
+file=""
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --password)
+      password=$2
+      shift 2
+      ;;
+    --salt)
+      salt=$2
+      shift 2
+      ;;
+	--file)
+      file=$2
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1"  >&2
+      exit 1
+      ;;
+  esac
+done
+
+
+if [ -z "$file" ]; then
+  echo "Error: The --file parameter is required. It must be a valid file path pointing to services.yml"  >&2
+  echo "Usage: $0 --file <file>"  >&2
+  echo "Example: $0 --file /Volumes/esp-sd/services.yml"  >&2
+  exit 1
+fi
+
+key=$(source $BASE_DIR/scripts/generate-key.sh --password "$password" --salt "$salt")
+
+echo "Using key: $key to decrypt services.yml"
+
+yq '.services[] | select(.secret != null) | .secret' "$file" | while IFS= read -r encrypted_secret; do
+  echo "Processing secret: $encrypted_secret"
+  if [ -z "$encrypted_secret" ]; then
+    echo "Error: Encrypted secret is empty or invalid"  >&2
+    exit 1
+  fi
+
+  decrypted_secret=$(echo "$encrypted_secret" | openssl enc -aes-256-ecb -d -K "$key" -base64 2>/dev/null)
+  if [ $? -ne 0 ]; then
+    echo "Error: Failed to decrypt secret: $encrypted_secret"  >&2
+    exit 1
+  fi
+
+  echo "Decrypted secret: $decrypted_secret"
+
+  yq -i "(.services[] | select(.secret == \"$encrypted_secret\") | .secret) = \"$decrypted_secret\"" "$file"
+done

--- a/scripts/encrypt-services.sh
+++ b/scripts/encrypt-services.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+set -e
+BASE_DIR=$(pwd)
+
+# NOTE: validate binary dependencies are installed
+if ! command -v openssl &>/dev/null; then
+  echo "Error: openssl is required but not installed. Please, refer to https://github.com/openssl/openssl" >&2
+  exit 1
+fi
+
+if ! command -v yq &>/dev/null; then
+  echo "Error: yq is required but not installed. Please, refer to https://github.com/mikefarah/yq" >&2
+  exit 1
+fi
+
+password=""
+salt=""
+file=""
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --password)
+      password=$2
+      shift 2
+      ;;
+    --salt)
+      salt=$2
+      shift 2
+      ;;
+	--file)
+      file=$2
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1"  >&2
+      exit 1
+      ;;
+  esac
+done
+
+
+if [ -z "$file" ]; then
+  echo "Error: The --file parameter is required. It must be a valid file path pointing to services.yml" >&2
+  echo "Usage: $0 --file <file>" >&2
+  echo "Example: $0 --file /Volumes/esp-sd/services.yml" >&2
+  exit 1
+fi
+
+key=$(source $BASE_DIR/scripts/generate-key.sh --password "$password" --salt "$salt")
+
+echo "Using key: $key to encrypt services.yml"
+
+yq '.services[] | select(.secret != null) | .secret' "$file" | while IFS= read -r decrypted_secret; do
+	echo "Processing secret: $decrypted_secret"
+	encrypted_secret=$(echo "$decrypted_secret" | openssl enc -aes-256-ecb -e -K "$key" -base64 2>/dev/null)
+
+	if [ $? -ne 0 ]; then
+		echo "Error: Failed to encrypt secret: $decrypted_secret" >&2
+		exit 1
+	fi
+	
+	# NOTE: this ensures the encrypted secret is stored as a single line
+	encrypted_secret=$(echo "$encrypted_secret" | tr -d "\n")
+	echo "Encrypted secret: $encrypted_secret"
+
+	yq -i "(.services[] | select(.secret == \"$decrypted_secret\") | .secret) = \"$encrypted_secret\"" "$file"
+done
+

--- a/scripts/generate-key.sh
+++ b/scripts/generate-key.sh
@@ -2,6 +2,16 @@
 
 set -e
 
+# TODO: make this random value between 10K and 100K, and store it in config.yml
+ITERATIONS=10000
+KEY_SIZE=32
+
+# NOTE: validate binary dependencies are installed
+if ! command -v openssl &>/dev/null; then
+  echo "Error: openssl is required but not installed. Please, refer to https://github.com/openssl/openssl" >&2
+  exit 1
+fi
+
 password=""
 salt=""
 while [[ $# -gt 0 ]]; do
@@ -22,22 +32,35 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [ -z "$password" ]; then
-  echo "Error: The --password parameter is required."
-  echo "Usage: $0 --password <password>"
-  echo "Example: $0 --password qw"
+  echo "Error: The --password parameter is required." >&2
+  echo "Usage: $0 --password <password>" >&2
+  echo "Example: $0 --password qw" >&2
   exit 1
 fi
 
 if [ -z "$salt" ]; then
-  echo "Error: The --salt parameter is required. It must be Base32 encoded"
-  echo "Usage: $0 --salt <salt>"
-  echo "Example: $0 --salt KXOFAZCLCES66ZW22ZWQVE2YMY======"
+  echo "Error: The --salt parameter is required. It must be Base32 encoded" >&2
+  echo "Usage: $0 --salt <salt>" >&2
+  echo "Example: $0 --salt KXOFAZCLCES66ZW22ZWQVE2YMY======" >&2
   exit 1
 fi
 
-ITERATIONS=10000
-KEY_SIZE=32
+decoded_salt=$(echo "$salt" | base32 --decode 2>/dev/null)
+if [ -z "$decoded_salt" ]; then
+  echo "Error: Failed to decode the Base32-encoded salt." >&2
+  exit 1
+fi
 
-DECODED_SALT=$(echo "$salt" | base32 --decode)
-GENERATED_KEY=$(openssl kdf -keylen $KEY_SIZE -kdfopt digest:SHA256 -kdfopt pass:$password -kdfopt salt:"$DECODED_SALT" -kdfopt iter:$ITERATIONS PBKDF2)
-echo "$GENERATED_KEY"
+key=$(openssl kdf \
+  -keylen $KEY_SIZE \
+  -kdfopt digest:SHA256 \
+  -kdfopt pass:$password \
+  -kdfopt salt:"$decoded_salt" \
+  -kdfopt iter:$ITERATIONS PBKDF2 2>/dev/null | tr -d ':')
+
+if [ -z "$key" ]; then
+  echo "Error: Failed to generate the encryption key." >&2
+  exit 1
+fi
+
+echo "$key"

--- a/scripts/generate-key.sh
+++ b/scripts/generate-key.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -e
+
+password=""
+salt=""
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --password)
+      password=$2
+      shift 2
+      ;;
+    --salt)
+      salt=$2
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$password" ]; then
+  echo "Error: The --password parameter is required."
+  echo "Usage: $0 --password <password>"
+  echo "Example: $0 --password qw"
+  exit 1
+fi
+
+if [ -z "$salt" ]; then
+  echo "Error: The --salt parameter is required. It must be Base32 encoded"
+  echo "Usage: $0 --salt <salt>"
+  echo "Example: $0 --salt KXOFAZCLCES66ZW22ZWQVE2YMY======"
+  exit 1
+fi
+
+ITERATIONS=10000
+KEY_SIZE=32
+
+DECODED_SALT=$(echo "$salt" | base32 --decode)
+GENERATED_KEY=$(openssl kdf -keylen $KEY_SIZE -kdfopt digest:SHA256 -kdfopt pass:$password -kdfopt salt:"$DECODED_SALT" -kdfopt iter:$ITERATIONS PBKDF2)
+echo "$GENERATED_KEY"

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -28,6 +28,9 @@ String Configuration::to_json_string(bool safe) const
 	_manager_authentication["password"] = manager.authentication.password;
 	_manager_authentication["session_length"] = manager.authentication.session_length;
 
+	JsonObject _encryption = doc.createNestedObject("encryption");
+	_encryption["salt"] = safe ? "*********" : encryption.salt;
+
 	String json;
 	serializeJson(doc, json);
 	return json;
@@ -130,6 +133,23 @@ Configuration Configuration::load()
 				config.manager.authentication.session_length = session_length > 0 ? session_length : MAX_MANAGER_SESSION_LENGTH;
 			}
 		}
+	}
+
+	if (root["encryption"].isMap())
+	{
+		if (root["encryption"]["salt"].isNull())
+		{
+			ESP_LOGE(TAG, "encryption.salt is empty");
+			throw std::runtime_error("encryption salt must be defined");
+		}
+
+		if (strlen(root.gettext("encryption:salt")) < 8)
+		{
+			ESP_LOGE(TAG, "encryption.salt must be at least 8 characters long");
+			throw std::runtime_error("encryption salt must be at least 8 characters long");
+		}
+
+		config.encryption.salt = root.gettext("encryption:salt");
 	}
 
 	ESP_LOGI(TAG, "config loaded successfully");

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -25,7 +25,8 @@ String Configuration::to_json_string(bool safe) const
 	JsonObject _manager = doc.createNestedObject("manager");
 	JsonObject _manager_authentication = _manager.createNestedObject("authentication");
 	_manager_authentication["username"] = manager.authentication.username;
-	_manager_authentication["password"] = manager.authentication.password;
+	_manager_authentication["password"] = safe ? "*********" : manager.authentication.password;
+	_manager_authentication["key"] = safe ? "*********" : manager.authentication.key;
 	_manager_authentication["session_length"] = manager.authentication.session_length;
 
 	JsonObject _encryption = doc.createNestedObject("encryption");

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -17,6 +17,10 @@ public:
 		String ssid = "";
 		String password = "";
 	} wifi;
+	struct EncryptionSettings
+	{
+		String salt = "";
+	} encryption;
 	struct ManagerSettings
 	{
 		struct ManagerAuthenticationSettings

--- a/src/constants.h
+++ b/src/constants.h
@@ -56,3 +56,5 @@
 #define KEY_SIZE 32
 #define ITERATIONS 10000
 #define KEY_FILE_PATH "/key.bin"
+#define MAX_PASSWORD_LENGTH 12
+#define MIN_PASSWORD_LENGTH 8

--- a/src/constants.h
+++ b/src/constants.h
@@ -30,11 +30,6 @@
 // NOTE: how many minutes the session is valid. For security purposes, sessions are set to 5 minutes but can be overwritten by the User in config.yml
 #define MAX_MANAGER_SESSION_LENGTH 5
 
-// UI
-#define PIN_SCREEN_NAME "pin"
-#define TOTP_SCREEN_NAME "totp"
-#define TOUCH_CALIBRATION_SCREEN_NAME "touch-calibration"
-
 // TOUCH
 #define TOUCH_DOUBLE_TOUCH_INTERVAL 300
 #define TOUCH_CALIBRATION_SPIFFS_FILE_PATH "/calibration.txt"

--- a/src/constants.h
+++ b/src/constants.h
@@ -50,3 +50,9 @@
 #define PWM_BITS_BCKL 8
 #define PWM_MAX_BCKL ((1 << PWM_BITS_BCKL) - 1)
 #define SLEEP_TIMEOUT 10
+
+// ENCRYPTION
+#define SALT_SIZE 16
+#define KEY_SIZE 32
+#define ITERATIONS 10000
+#define KEY_FILE_PATH "/key.bin"

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -48,7 +48,8 @@ void reset_display_off_timer()
 
 void check_display_timeout()
 {
-    if (sleep_timeout)
+    lv_obj_t *active_screen = lv_scr_act();
+    if (sleep_timeout && (active_screen == ui_totp_screen || active_screen == ui_pin_screen))
     {
         unsigned long elapsed_time = millis() - time_display_turned_off;
         if (elapsed_time >= sleep_timeout && display_is_active)
@@ -68,8 +69,7 @@ void display_handle_single_touch()
 void display_handle_double_touch()
 {
     lv_obj_t *active_screen = lv_scr_act();
-    const char *active_screen_name = (const char *)lv_obj_get_user_data(active_screen);
-    if (strcmp(active_screen_name, TOTP_SCREEN_NAME) == 0)
+    if (active_screen == ui_totp_screen)
     {
 
         if (display_is_active)

--- a/src/encryption.cpp
+++ b/src/encryption.cpp
@@ -1,0 +1,214 @@
+#include "encryption.hpp"
+
+static const char *TAG = "main";
+
+const unsigned char *_salt;
+
+bool key_exists()
+{
+	return is_file_available(SPIFFS, KEY_FILE_PATH);
+}
+
+void generate_key(const char *password)
+{
+	uint8_t key[KEY_SIZE];
+	mbedtls_entropy_context entropy;
+	mbedtls_ctr_drbg_context ctr_drbg;
+	mbedtls_md_context_t md_ctx;
+
+	mbedtls_entropy_init(&entropy);
+	mbedtls_ctr_drbg_init(&ctr_drbg);
+
+	const char *personalization = "key_gen";
+	int ret = mbedtls_ctr_drbg_seed(
+		&ctr_drbg,
+		mbedtls_entropy_func,
+		&entropy,
+		(const unsigned char *)personalization,
+		strlen(personalization));
+	if (ret != 0)
+	{
+		ESP_LOGD(TAG, "CTR-DRBG seed initialization failed with error: %d", ret);
+		mbedtls_entropy_free(&entropy);
+		return;
+	}
+
+	mbedtls_md_init(&md_ctx);
+	ret = mbedtls_md_setup(
+		&md_ctx,
+		mbedtls_md_info_from_type(MBEDTLS_MD_SHA256),
+		0);
+	if (ret != 0)
+	{
+		ESP_LOGE(TAG, "Failed to setup MD context");
+		mbedtls_ctr_drbg_free(&ctr_drbg);
+		mbedtls_entropy_free(&entropy);
+		return;
+	}
+
+	ret = mbedtls_pkcs5_pbkdf2_hmac(
+		&md_ctx,
+		(const unsigned char *)password,
+		strlen(password),
+		_salt,
+		SALT_SIZE,
+		ITERATIONS,
+		KEY_SIZE,
+		key);
+	if (ret != 0)
+	{
+		ESP_LOGE(TAG, "Key derivation failed with error: %d", ret);
+	}
+	else
+	{
+		ESP_LOGI(TAG, "Key successfully derived");
+	}
+
+	mbedtls_md_free(&md_ctx);
+	mbedtls_ctr_drbg_free(&ctr_drbg);
+	mbedtls_entropy_free(&entropy);
+
+	File file = SPIFFS.open(KEY_FILE_PATH, FILE_WRITE);
+	if (!file)
+	{
+		ESP_LOGD(TAG, "Failed to open file for writing");
+		return;
+	}
+
+	if (file.write(key, KEY_SIZE) != KEY_SIZE)
+	{
+		ESP_LOGD(TAG, "Failed to write the entire key to SPIFFS");
+	}
+	else
+	{
+		ESP_LOGD(TAG, "Key successfully stored in SPIFFS");
+	}
+	file.close();
+}
+
+bool load_key(uint8_t *key)
+{
+	File keyFile = SPIFFS.open(KEY_FILE_PATH, FILE_READ);
+	if (!keyFile)
+	{
+		ESP_LOGD(TAG, "Failed to open key file");
+		return false;
+	}
+
+	if (keyFile.read(key, KEY_SIZE) != KEY_SIZE)
+	{
+		ESP_LOGD(TAG, "Failed to read the complete key");
+		keyFile.close();
+		return false;
+	}
+
+	keyFile.close();
+	return true;
+}
+
+bool decrypt_text(const char *input, char *output, size_t output_len)
+{
+	size_t input_len = strlen(input);
+	uint8_t key[KEY_SIZE];
+	if (!load_key(key))
+	{
+		return false;
+	}
+
+	mbedtls_aes_context aes;
+	mbedtls_aes_init(&aes);
+
+	if (mbedtls_aes_setkey_dec(&aes, key, KEY_SIZE * 8) != 0)
+	{
+		ESP_LOGD(TAG, "Failed to set AES decryption key");
+		mbedtls_aes_free(&aes);
+		return false;
+	}
+
+	if (input_len % 16 != 0)
+	{
+		ESP_LOGD(TAG, "Input length must be a multiple of AES block size (16 bytes)");
+		mbedtls_aes_free(&aes);
+		return false;
+	}
+
+	for (size_t i = 0; i < input_len; i += 16)
+	{
+		if (mbedtls_aes_crypt_ecb(&aes, MBEDTLS_AES_DECRYPT,
+								  (const unsigned char *)(input + i),
+								  (unsigned char *)(output + i)) != 0)
+		{
+			ESP_LOGD(TAG, "Decryption failed at block %zu", i / 16);
+			mbedtls_aes_free(&aes);
+			return false;
+		}
+	}
+
+	if (input_len < output_len)
+	{
+		output[input_len] = '\0';
+	}
+
+	mbedtls_aes_free(&aes);
+	return true;
+}
+
+bool encrypt_text(const char *input, char *output, size_t output_len)
+{
+	size_t input_len = strlen(input);
+	uint8_t key[KEY_SIZE];
+	if (!load_key(key))
+	{
+		return false;
+	}
+
+	mbedtls_aes_context aes;
+	mbedtls_aes_init(&aes);
+
+	if (mbedtls_aes_setkey_enc(&aes, key, KEY_SIZE * 8) != 0)
+	{
+		ESP_LOGD(TAG, "Failed to set AES encryption key");
+		mbedtls_aes_free(&aes);
+		return false;
+	}
+
+	size_t padded_len = (input_len + 15) / 16 * 16;
+	if (padded_len > output_len)
+	{
+		ESP_LOGD(TAG, "Output buffer too small for encrypted data");
+		mbedtls_aes_free(&aes);
+		return false;
+	}
+
+	char *padded_input = (char *)malloc(padded_len);
+	if (!padded_input)
+	{
+		ESP_LOGD(TAG, "Failed to allocate memory for padded input");
+		mbedtls_aes_free(&aes);
+		return false;
+	}
+	memcpy(padded_input, input, input_len);
+	memset(padded_input + input_len, padded_len - input_len, padded_len - input_len);
+
+	for (size_t i = 0; i < padded_len; i += 16)
+	{
+		if (mbedtls_aes_crypt_ecb(&aes, MBEDTLS_AES_ENCRYPT,
+								  (const unsigned char *)(padded_input + i),
+								  (unsigned char *)(output + i)) != 0)
+		{
+			ESP_LOGD(TAG, "Encryption failed at block %zu", i / 16);
+			free(padded_input);
+			mbedtls_aes_free(&aes);
+			return false;
+		}
+	}
+
+	free(padded_input);
+	mbedtls_aes_free(&aes);
+	return true;
+}
+
+void init_encryption(const char *salt)
+{
+	_salt = (const unsigned char *)salt;
+}

--- a/src/encryption.hpp
+++ b/src/encryption.hpp
@@ -14,7 +14,7 @@ extern "C"
 
 	void init_encryption(const char *salt);
 	bool key_exists();
-	void generate_key(const char *password);
+	bool generate_key(const char *password);
 	bool decrypt_text(const char *input, char *output, size_t output_len);
 	bool encrypt_text(const char *input, char *output, size_t output_len);
 
@@ -23,8 +23,9 @@ extern "C"
 
 #include <SPIFFS.h>
 #include <esp_log.h>
+#include <Base32.h>
 #include "storage.hpp"
-
+#include "config.hpp"
 #endif
 
 #endif // ENCRYPTION_H

--- a/src/encryption.hpp
+++ b/src/encryption.hpp
@@ -1,0 +1,30 @@
+#ifndef ENCRYPTION_H
+#define ENCRYPTION_H
+
+#include <mbedtls/md.h>
+#include <mbedtls/pkcs5.h>
+#include <mbedtls/entropy.h>
+#include <mbedtls/ctr_drbg.h>
+#include "constants.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+	void init_encryption(const char *salt);
+	bool key_exists();
+	void generate_key(const char *password);
+	bool decrypt_text(const char *input, char *output, size_t output_len);
+	bool encrypt_text(const char *input, char *output, size_t output_len);
+
+#ifdef __cplusplus
+}
+
+#include <SPIFFS.h>
+#include <esp_log.h>
+#include "storage.hpp"
+
+#endif
+
+#endif // ENCRYPTION_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,7 @@
 #include "wifi.hpp"
 #include "touch-screen.hpp"
 #include "manager.hpp"
+#include "encryption.hpp"
 
 static const char *TAG = "main";
 
@@ -33,9 +34,9 @@ void setup()
 #endif
   ESP_LOGI(TAG, "----------- begin setup ------------");
   init_storage();
-  load_services();
   Configuration config = Configuration::load();
-
+  init_encryption(config.encryption.salt.c_str());
+  load_services();
   init_auth(
       config.authentication.pin.hash.c_str(),
       config.authentication.pin.key.c_str(),
@@ -46,7 +47,6 @@ void setup()
   init_touch_screen(config);
   const char *local_network_ip = init_wifi(config).c_str();
   init_clock();
-
   if (config.is_manager_configured())
   {
     init_manager(config, local_network_ip);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -66,6 +66,7 @@ void loop()
   switch (application_state)
   {
   case START:
+    static unsigned long state_change_time = 0;
     if (touch_is_calibrated())
     {
       application_state = TOUCH_CALIBRATION_COMPLETE;
@@ -74,10 +75,10 @@ void loop()
     {
       application_state = TOUCH_CALIBRATION_START;
     }
+    state_change_time = millis();
     break;
 
   case TOUCH_CALIBRATION_START:
-    static unsigned long state_change_time = 0;
     lv_scr_load(ui_touch_calibration_screen);
     application_state = TOUCH_CALIBRATION_MIN;
     state_change_time = millis();
@@ -98,6 +99,7 @@ void loop()
     {
       touch_calibrate_max();
       application_state = TOUCH_CALIBRATION_UPDATE;
+      state_change_time = millis();
     }
     break;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,7 +53,8 @@ void setup()
   }
   init_ui(
       config.is_authentication_configured(),
-      config.authentication.unlock_attempts);
+      config.authentication.unlock_attempts,
+      !config.encryption.salt.isEmpty() || !key_exists());
   ESP_LOGI(TAG, "----------- end setup ------------");
 }
 

--- a/src/touch-screen.cpp
+++ b/src/touch-screen.cpp
@@ -31,7 +31,5 @@ void init_touch_screen(Configuration config)
 
 void display_timeout_handler()
 {
-	ESP_LOGV(TAG, "calling display timeout handler");
 	check_display_timeout();
-	ESP_LOGV(TAG, "display timeout handler called");
 }

--- a/src/ui/screens/ui_key_creation_screen.c
+++ b/src/ui/screens/ui_key_creation_screen.c
@@ -4,17 +4,75 @@
 void ui_key_creation_screen_init(void)
 {
 	ui_key_creation_screen = lv_obj_create(NULL);
+	lv_obj_set_flex_flow(ui_key_creation_screen, LV_FLEX_FLOW_COLUMN);
+	lv_obj_set_flex_align(ui_key_creation_screen, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
+	lv_obj_set_layout(ui_key_creation_screen, LV_LAYOUT_FLEX);
+	lv_obj_set_style_pad_row(ui_key_creation_screen, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_pad_all(ui_key_creation_screen, 0, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_scrollbar_mode(ui_key_creation_screen, LV_SCROLLBAR_MODE_OFF);
+	lv_obj_set_style_bg_color(ui_key_creation_screen, lv_color_make(12, 18, 30), LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_bg_opa(ui_key_creation_screen, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
 
-	ui_key_creation_screen_password_textarea = lv_textarea_create(ui_key_creation_screen);
-	lv_obj_set_size(ui_key_creation_screen_password_textarea, 230, 50);
-	lv_obj_align(ui_key_creation_screen_password_textarea, LV_ALIGN_TOP_MID, 0, 20);
+	lv_obj_t *password_textareas_container = lv_obj_create(ui_key_creation_screen);
+	lv_obj_set_width(password_textareas_container, LV_HOR_RES);
+	lv_obj_set_height(password_textareas_container, LV_SIZE_CONTENT);
+	lv_obj_set_flex_flow(password_textareas_container, LV_FLEX_FLOW_COLUMN);
+	lv_obj_set_flex_align(password_textareas_container, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
+	lv_obj_set_scrollbar_mode(password_textareas_container, LV_SCROLLBAR_MODE_OFF);
+	lv_obj_set_style_pad_all(password_textareas_container, 5, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_radius(password_textareas_container, 0, 0);
+	lv_obj_set_style_border_opa(password_textareas_container, LV_OPA_TRANSP, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_bg_color(password_textareas_container, lv_color_make(12, 18, 30), LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_bg_opa(password_textareas_container, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+	ui_key_creation_screen_password_textarea = lv_textarea_create(password_textareas_container);
+	lv_obj_set_width(ui_key_creation_screen_password_textarea, LV_HOR_RES - 15);
+	lv_obj_set_height(ui_key_creation_screen_password_textarea, 40);
+	lv_obj_set_style_text_align(ui_key_creation_screen_password_textarea, LV_TEXT_ALIGN_CENTER, 0);
 	lv_textarea_set_password_mode(ui_key_creation_screen_password_textarea, true);
 	lv_textarea_set_placeholder_text(ui_key_creation_screen_password_textarea, "Enter password");
 	lv_textarea_set_max_length(ui_key_creation_screen_password_textarea, MAX_PASSWORD_LENGTH);
+	lv_textarea_set_one_line(ui_key_creation_screen_password_textarea, true);
+	lv_obj_set_style_text_font(ui_key_creation_screen_password_textarea, &lv_font_montserrat_14, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_text_color(ui_key_creation_screen_password_textarea, lv_color_make(254, 254, 254), LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_text_color(ui_key_creation_screen_password_textarea, lv_color_make(254, 254, 254), LV_PART_TEXTAREA_PLACEHOLDER);
+	lv_obj_set_style_bg_color(ui_key_creation_screen_password_textarea, lv_color_make(3, 6, 10), LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_border_opa(ui_key_creation_screen_password_textarea, LV_OPA_TRANSP, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+	ui_key_creation_screen_password_confirmation_textarea = lv_textarea_create(password_textareas_container);
+	lv_obj_set_width(ui_key_creation_screen_password_confirmation_textarea, LV_HOR_RES - 15);
+	lv_obj_set_height(ui_key_creation_screen_password_confirmation_textarea, 40);
+	lv_obj_set_style_text_align(ui_key_creation_screen_password_confirmation_textarea, LV_TEXT_ALIGN_CENTER, 0);
+	lv_textarea_set_password_mode(ui_key_creation_screen_password_confirmation_textarea, true);
+	lv_textarea_set_placeholder_text(ui_key_creation_screen_password_confirmation_textarea, "Confirm password");
+	lv_textarea_set_max_length(ui_key_creation_screen_password_confirmation_textarea, MAX_PASSWORD_LENGTH);
+	lv_textarea_set_one_line(ui_key_creation_screen_password_confirmation_textarea, true);
+	lv_obj_set_style_text_font(ui_key_creation_screen_password_confirmation_textarea, &lv_font_montserrat_14, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_text_color(ui_key_creation_screen_password_confirmation_textarea, lv_color_make(254, 254, 254), LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_text_color(ui_key_creation_screen_password_confirmation_textarea, lv_color_make(254, 254, 254), LV_PART_TEXTAREA_PLACEHOLDER);
+	lv_obj_set_style_bg_color(ui_key_creation_screen_password_confirmation_textarea, lv_color_make(3, 6, 10), LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_style_border_opa(ui_key_creation_screen_password_confirmation_textarea, LV_OPA_TRANSP, LV_PART_MAIN | LV_STATE_DEFAULT);
 
 	lv_obj_t *keyboard = lv_keyboard_create(ui_key_creation_screen);
 	lv_keyboard_set_textarea(keyboard, ui_key_creation_screen_password_textarea);
 	lv_obj_align(keyboard, LV_ALIGN_BOTTOM_MID, 0, 0);
+	lv_obj_set_style_pad_all(keyboard, 10, LV_PART_MAIN | LV_STATE_DEFAULT);
+	lv_obj_set_flex_grow(keyboard, 2);
+	lv_obj_set_style_bg_color(keyboard, lv_color_make(0, 0, 0), LV_PART_MAIN | LV_STATE_DEFAULT);
+
+	static lv_style_t buttons_style;
+	lv_style_init(&buttons_style);
+	lv_style_set_text_color(&buttons_style, lv_color_make(254, 254, 254));
+	lv_style_set_bg_color(&buttons_style, lv_color_make(9, 18, 30));
+	lv_obj_add_style(keyboard, &buttons_style, LV_PART_ITEMS);
+
+	static lv_style_t buttons_style_checked_state;
+	lv_style_init(&buttons_style_checked_state);
+	lv_style_set_text_color(&buttons_style_checked_state, lv_color_make(254, 254, 254));
+	lv_style_set_bg_color(&buttons_style_checked_state, lv_color_make(3, 6, 10));
+	lv_obj_add_style(keyboard, &buttons_style_checked_state, LV_PART_ITEMS | LV_STATE_CHECKED);
 
 	lv_obj_add_event_cb(keyboard, ui_event_key_creation_screen_keybard, LV_EVENT_ALL, NULL);
+	lv_obj_add_event_cb(ui_key_creation_screen_password_textarea, ui_event_key_creation_screen_textarea, LV_EVENT_ALL, keyboard);
+	lv_obj_add_event_cb(ui_key_creation_screen_password_confirmation_textarea, ui_event_key_creation_screen_textarea, LV_EVENT_ALL, keyboard);
 }

--- a/src/ui/screens/ui_key_creation_screen.c
+++ b/src/ui/screens/ui_key_creation_screen.c
@@ -1,18 +1,20 @@
 #include "../ui.h"
+#include "constants.h"
 
 void ui_key_creation_screen_init(void)
 {
 	ui_key_creation_screen = lv_obj_create(NULL);
 
 	ui_key_creation_screen_password_textarea = lv_textarea_create(ui_key_creation_screen);
-	lv_obj_set_size(ui_key_creation_screen_password_textarea, 200, 50);
+	lv_obj_set_size(ui_key_creation_screen_password_textarea, 230, 50);
 	lv_obj_align(ui_key_creation_screen_password_textarea, LV_ALIGN_TOP_MID, 0, 20);
 	lv_textarea_set_password_mode(ui_key_creation_screen_password_textarea, true);
 	lv_textarea_set_placeholder_text(ui_key_creation_screen_password_textarea, "Enter password");
+	lv_textarea_set_max_length(ui_key_creation_screen_password_textarea, MAX_PASSWORD_LENGTH);
 
 	lv_obj_t *keyboard = lv_keyboard_create(ui_key_creation_screen);
 	lv_keyboard_set_textarea(keyboard, ui_key_creation_screen_password_textarea);
 	lv_obj_align(keyboard, LV_ALIGN_BOTTOM_MID, 0, 0);
 
-	lv_obj_add_event_cb(keyboard, ui_event_key_creation_screen_keybard, LV_EVENT_CLICKED, NULL);
+	lv_obj_add_event_cb(keyboard, ui_event_key_creation_screen_keybard, LV_EVENT_ALL, NULL);
 }

--- a/src/ui/screens/ui_key_creation_screen.c
+++ b/src/ui/screens/ui_key_creation_screen.c
@@ -1,0 +1,18 @@
+#include "../ui.h"
+
+void ui_key_creation_screen_init(void)
+{
+	ui_key_creation_screen = lv_obj_create(NULL);
+
+	ui_key_creation_screen_password_textarea = lv_textarea_create(ui_key_creation_screen);
+	lv_obj_set_size(ui_key_creation_screen_password_textarea, 200, 50);
+	lv_obj_align(ui_key_creation_screen_password_textarea, LV_ALIGN_TOP_MID, 0, 20);
+	lv_textarea_set_password_mode(ui_key_creation_screen_password_textarea, true);
+	lv_textarea_set_placeholder_text(ui_key_creation_screen_password_textarea, "Enter password");
+
+	lv_obj_t *keyboard = lv_keyboard_create(ui_key_creation_screen);
+	lv_keyboard_set_textarea(keyboard, ui_key_creation_screen_password_textarea);
+	lv_obj_align(keyboard, LV_ALIGN_BOTTOM_MID, 0, 0);
+
+	lv_obj_add_event_cb(keyboard, ui_event_key_creation_screen_keybard, LV_EVENT_CLICKED, NULL);
+}

--- a/src/ui/screens/ui_pin_screen.c
+++ b/src/ui/screens/ui_pin_screen.c
@@ -4,8 +4,6 @@
 void ui_pin_screen_init(void)
 {
     ui_pin_screen = lv_obj_create(NULL);
-    const char *name = PIN_SCREEN_NAME;
-    lv_obj_set_user_data(ui_pin_screen, (void *)name);
     lv_obj_add_flag(ui_pin_screen, LV_OBJ_FLAG_SCROLLABLE);
     lv_obj_set_scrollbar_mode(ui_pin_screen, LV_SCROLLBAR_MODE_OFF);
     lv_obj_set_style_bg_color(ui_pin_screen, lv_color_make(12, 18, 30), LV_PART_MAIN | LV_STATE_DEFAULT);

--- a/src/ui/screens/ui_totp_screen.c
+++ b/src/ui/screens/ui_totp_screen.c
@@ -55,8 +55,6 @@ lv_obj_t *create_totp_component(
 void ui_totp_screen_init(void)
 {
     ui_totp_screen = lv_obj_create(NULL);
-    const char *name = TOTP_SCREEN_NAME;
-    lv_obj_set_user_data(ui_totp_screen, (void *)name);
     lv_obj_add_flag(ui_totp_screen, LV_OBJ_FLAG_SCROLLABLE);
     lv_obj_set_scrollbar_mode(ui_totp_screen, LV_SCROLLBAR_MODE_OFF);
     lv_obj_set_style_bg_color(ui_totp_screen, lv_color_make(12, 18, 30), LV_PART_MAIN | LV_STATE_DEFAULT);

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -2,10 +2,11 @@
 
 static const char *TAG = "ui";
 
-uint32_t LV_EVENT_SETUP_COMPLETE;
 lv_obj_t *ui_init_screen;
 lv_obj_t *ui_totp_screen;
 lv_obj_t *ui_pin_screen;
+lv_obj_t *ui_key_creation_screen;
+lv_obj_t *ui_key_creation_screen_password_textarea;
 lv_obj_t *ui_touch_calibration_screen;
 lv_obj_t *ui_pin_screen_textarea;
 lv_obj_t *ui_touch_calibration_screen_label;
@@ -17,6 +18,7 @@ void ui_pin_screen_init(void);
 void ui_event_totp_screen(lv_event_t *e);
 void ui_event_pin_screen_keyboard_button(lv_event_t *e);
 void ui_event_pin_screen_textarea(lv_event_t *e);
+void ui_event_key_creation_screen_keybard(lv_event_t *e);
 void ui_totp_screen_update_totp_labels();
 void ui_totp_screen_update_totp_countdowns();
 void ui_totp_screen_render_totp_components();
@@ -57,6 +59,15 @@ void ui_event_pin_screen_textarea(lv_event_t *e)
     }
 }
 
+void ui_event_key_creation_screen_keybard(lv_event_t *e)
+{
+    lv_event_code_t event_code = lv_event_get_code(e);
+    if (event_code == LV_EVENT_READY)
+    {
+        on_key_creation_form_submit(e);
+    }
+}
+
 void init_ui(
     bool display_pin_screen,
     int max_unlock_attempts)
@@ -73,10 +84,10 @@ void init_ui(
         lv_palette_main(LV_PALETTE_RED),
         true,
         LV_FONT_DEFAULT);
-    LV_EVENT_SETUP_COMPLETE = lv_event_register_id();
     lv_disp_set_theme(disp, theme);
     // NOTE: initialize screens
     ui_touch_calibration_screen_init();
+    ui_key_creation_screen_init();
     ui_totp_screen_init();
     ui_pin_screen_init();
     ESP_LOGI(TAG, "ui initialized");
@@ -84,14 +95,7 @@ void init_ui(
 
 void load_first_screen()
 {
-    if (config.display_pin_screen)
-    {
-        lv_scr_load(ui_pin_screen);
-    }
-    else
-    {
-        lv_scr_load(ui_totp_screen);
-    }
+    lv_scr_load(ui_key_creation_screen);
 }
 
 void ui_task_handler()

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -7,6 +7,7 @@ lv_obj_t *ui_totp_screen;
 lv_obj_t *ui_pin_screen;
 lv_obj_t *ui_key_creation_screen;
 lv_obj_t *ui_key_creation_screen_password_textarea;
+lv_obj_t *ui_key_creation_screen_password_confirmation_textarea;
 lv_obj_t *ui_touch_calibration_screen;
 lv_obj_t *ui_pin_screen_textarea;
 lv_obj_t *ui_touch_calibration_screen_label;
@@ -19,6 +20,7 @@ void ui_event_totp_screen(lv_event_t *e);
 void ui_event_pin_screen_keyboard_button(lv_event_t *e);
 void ui_event_pin_screen_textarea(lv_event_t *e);
 void ui_event_key_creation_screen_keybard(lv_event_t *e);
+void ui_event_key_creation_screen_textarea(lv_event_t *e);
 void ui_totp_screen_update_totp_labels();
 void ui_totp_screen_update_totp_countdowns();
 void ui_totp_screen_render_totp_components();
@@ -65,6 +67,15 @@ void ui_event_key_creation_screen_keybard(lv_event_t *e)
     if (event_code == LV_EVENT_READY)
     {
         on_key_creation_screen_form_submit(e);
+    }
+}
+
+void ui_event_key_creation_screen_textarea(lv_event_t *e)
+{
+    lv_event_code_t event_code = lv_event_get_code(e);
+    if (event_code == LV_EVENT_CLICKED)
+    {
+        on_key_creation_screen_textarea_focus(e);
     }
 }
 

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -64,18 +64,20 @@ void ui_event_key_creation_screen_keybard(lv_event_t *e)
     lv_event_code_t event_code = lv_event_get_code(e);
     if (event_code == LV_EVENT_READY)
     {
-        on_key_creation_form_submit(e);
+        on_key_creation_screen_form_submit(e);
     }
 }
 
 void init_ui(
     bool display_pin_screen,
-    int max_unlock_attempts)
+    int max_unlock_attempts,
+    bool create_encryption_key)
 {
     ESP_LOGI(TAG, "initializing ui");
     config.display_pin_screen = display_pin_screen;
     config.unlock_attempts = max_unlock_attempts;
     config.max_unlock_attempts = max_unlock_attempts;
+    config.create_encryption_key = create_encryption_key;
 
     lv_disp_t *disp = lv_disp_get_default();
     lv_theme_t *theme = lv_theme_default_init(
@@ -87,15 +89,32 @@ void init_ui(
     lv_disp_set_theme(disp, theme);
     // NOTE: initialize screens
     ui_touch_calibration_screen_init();
-    ui_key_creation_screen_init();
     ui_totp_screen_init();
     ui_pin_screen_init();
+    if (create_encryption_key)
+    {
+        ui_key_creation_screen_init();
+    }
     ESP_LOGI(TAG, "ui initialized");
 }
 
 void load_first_screen()
 {
-    lv_scr_load(ui_key_creation_screen);
+    if (config.create_encryption_key)
+    {
+        lv_scr_load(ui_key_creation_screen);
+    }
+    else
+    {
+        if (config.display_pin_screen)
+        {
+            lv_scr_load(ui_pin_screen);
+        }
+        else
+        {
+            lv_scr_load(ui_totp_screen);
+        }
+    }
 }
 
 void ui_task_handler()

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -21,6 +21,8 @@ extern "C"
 
 	extern lv_obj_t *ui_totp_screen;
 	extern lv_obj_t *ui_pin_screen;
+	extern lv_obj_t *ui_key_creation_screen;
+	extern lv_obj_t *ui_key_creation_screen_password_textarea;
 	extern lv_obj_t *ui_touch_calibration_screen;
 	extern lv_obj_t *ui_pin_screen_textarea;
 	extern lv_obj_t *ui_touch_calibration_screen_label;
@@ -30,6 +32,7 @@ extern "C"
 	void ui_event_totp_screen(lv_event_t *e);
 	void ui_event_pin_screen_keyboard_button(lv_event_t *e);
 	void ui_event_pin_screen_textarea(lv_event_t *e);
+	void ui_event_key_creation_screen_keybard(lv_event_t *e);
 	void init_ui(bool display_pin_screen,
 				 int max_unlock_attempts);
 	void load_first_screen();
@@ -43,7 +46,7 @@ extern "C"
 	void ui_touch_calibration_screen_destroy();
 
 #ifdef __cplusplus
-} /*extern "C"*/
+}
 #endif
 
 #ifdef __cplusplus

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -24,6 +24,7 @@ extern "C"
 	extern lv_obj_t *ui_pin_screen;
 	extern lv_obj_t *ui_key_creation_screen;
 	extern lv_obj_t *ui_key_creation_screen_password_textarea;
+	extern lv_obj_t *ui_key_creation_screen_password_confirmation_textarea;
 	extern lv_obj_t *ui_touch_calibration_screen;
 	extern lv_obj_t *ui_pin_screen_textarea;
 	extern lv_obj_t *ui_touch_calibration_screen_label;
@@ -34,6 +35,7 @@ extern "C"
 	void ui_event_pin_screen_keyboard_button(lv_event_t *e);
 	void ui_event_pin_screen_textarea(lv_event_t *e);
 	void ui_event_key_creation_screen_keybard(lv_event_t *e);
+	void ui_event_key_creation_screen_textarea(lv_event_t *e);
 	void init_ui(bool display_pin_screen,
 				 int max_unlock_attempts,
 				 bool create_encryption_key);

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -17,6 +17,7 @@ extern "C"
 		int unlock_attempts;
 		int max_unlock_attempts;
 		bool display_pin_screen;
+		bool create_encryption_key;
 	} Config;
 
 	extern lv_obj_t *ui_totp_screen;
@@ -34,7 +35,8 @@ extern "C"
 	void ui_event_pin_screen_textarea(lv_event_t *e);
 	void ui_event_key_creation_screen_keybard(lv_event_t *e);
 	void init_ui(bool display_pin_screen,
-				 int max_unlock_attempts);
+				 int max_unlock_attempts,
+				 bool create_encryption_key);
 	void load_first_screen();
 	void ui_task_handler();
 	void ui_totp_screen_update_totp_labels();

--- a/src/ui/ui_events.c
+++ b/src/ui/ui_events.c
@@ -106,12 +106,13 @@ void on_key_creation_screen_form_submit(lv_event_t *e)
 
     if (strcmp(password, password_confirmation) != 0)
     {
-        char message[128];
-        sprintf(message, "Passwords do not match. Please try again");
-        lv_obj_center(lv_msgbox_create(NULL, "ERROR", message, NULL, true));
+        lv_obj_center(lv_msgbox_create(NULL, "ERROR", "Passwords do not match. Please try again", NULL, true));
         return;
     }
 
+    lv_obj_center(lv_msgbox_create(NULL, NULL, "creating key...", NULL, false));
+
+    // TODO: handle errors
     generate_key(password);
 
     if (config.display_pin_screen)

--- a/src/ui/ui_events.c
+++ b/src/ui/ui_events.c
@@ -6,6 +6,7 @@
 #include "constants.h"
 #include "auth.h"
 #include "mfa.h"
+#include "encryption.hpp"
 
 static const char *TAG = "ui_events";
 
@@ -77,4 +78,12 @@ void on_pin_screen_form_submit(lv_event_t *e)
     config.unlock_attempts = config.max_unlock_attempts;
 
     lv_scr_load(ui_totp_screen);
+}
+
+void on_key_creation_form_submit(lv_event_t *e)
+{
+    const char *password = lv_textarea_get_text(ui_key_creation_screen_password_textarea);
+
+    ESP_LOGD(TAG, "Password: %s\n", password);
+    generate_key(password);
 }

--- a/src/ui/ui_events.c
+++ b/src/ui/ui_events.c
@@ -80,10 +80,20 @@ void on_pin_screen_form_submit(lv_event_t *e)
     lv_scr_load(ui_totp_screen);
 }
 
+void on_key_creation_screen_textarea_focus(lv_event_t *e)
+{
+    lv_obj_t *focused_textarea = lv_event_get_target(e);
+    lv_obj_t *keyboard = lv_event_get_user_data(e);
+
+    lv_keyboard_set_textarea(keyboard, focused_textarea);
+}
+
 void on_key_creation_screen_form_submit(lv_event_t *e)
 {
     const char *password = lv_textarea_get_text(ui_key_creation_screen_password_textarea);
+    const char *password_confirmation = lv_textarea_get_text(ui_key_creation_screen_password_confirmation_textarea);
     ESP_LOGD(TAG, "Password: %s\n", password);
+    ESP_LOGD(TAG, "Password Confirmation: %s\n", password_confirmation);
 
     size_t password_len = strlen(password);
     if (password_len < MIN_PASSWORD_LENGTH)
@@ -94,8 +104,22 @@ void on_key_creation_screen_form_submit(lv_event_t *e)
         return;
     }
 
-    if (!generate_key(password))
+    if (strcmp(password, password_confirmation) != 0)
     {
-        ESP_LOGE(TAG, "Error while generating key");
+        char message[128];
+        sprintf(message, "Passwords do not match. Please try again");
+        lv_obj_center(lv_msgbox_create(NULL, "ERROR", message, NULL, true));
+        return;
+    }
+
+    generate_key(password);
+
+    if (config.display_pin_screen)
+    {
+        lv_scr_load(ui_pin_screen);
+    }
+    else
+    {
+        lv_scr_load(ui_totp_screen);
     }
 }

--- a/src/ui/ui_events.c
+++ b/src/ui/ui_events.c
@@ -80,10 +80,22 @@ void on_pin_screen_form_submit(lv_event_t *e)
     lv_scr_load(ui_totp_screen);
 }
 
-void on_key_creation_form_submit(lv_event_t *e)
+void on_key_creation_screen_form_submit(lv_event_t *e)
 {
     const char *password = lv_textarea_get_text(ui_key_creation_screen_password_textarea);
-
     ESP_LOGD(TAG, "Password: %s\n", password);
-    generate_key(password);
+
+    size_t password_len = strlen(password);
+    if (password_len < MIN_PASSWORD_LENGTH)
+    {
+        char message[128];
+        sprintf(message, "Password is too short. Minimum %d characters is required", MIN_PASSWORD_LENGTH);
+        lv_obj_center(lv_msgbox_create(NULL, "ERROR", message, NULL, true));
+        return;
+    }
+
+    if (!generate_key(password))
+    {
+        ESP_LOGE(TAG, "Error while generating key");
+    }
 }

--- a/src/ui/ui_events.h
+++ b/src/ui/ui_events.h
@@ -2,6 +2,7 @@
 #define UI_EVENTS_H
 
 #ifdef __cplusplus
+
 extern "C"
 {
 #endif
@@ -14,9 +15,10 @@ extern "C"
     void on_totp_screen_gesture(lv_event_t *e);
     void on_screen_keyboard_button_clicked(lv_event_t *e);
     void on_pin_screen_form_submit(lv_event_t *e);
+    void on_key_creation_form_submit(lv_event_t *e);
 
 #ifdef __cplusplus
-} /*extern "C"*/
+}
 #endif
 
 #endif // UI_EVENTS_H

--- a/src/ui/ui_events.h
+++ b/src/ui/ui_events.h
@@ -15,7 +15,7 @@ extern "C"
     void on_totp_screen_gesture(lv_event_t *e);
     void on_screen_keyboard_button_clicked(lv_event_t *e);
     void on_pin_screen_form_submit(lv_event_t *e);
-    void on_key_creation_form_submit(lv_event_t *e);
+    void on_key_creation_screen_form_submit(lv_event_t *e);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
During boot,  users are prompted to provide a password to create a new encryption key. If a salt is available in `config.yml` it will be used to generate the key, otherwise a new one will be created.

For more details, see [Key derivation function](https://en.wikipedia.org/wiki/Key_derivation_function).

After submiting the password form, the encryption key is created, and the salt is written as a Base32 encoded string to `config.yml`, which is stored in the SD card.


![20250112_224907.jpg](https://github.com/user-attachments/assets/5b286112-a6fd-441f-a9c9-da07f24c8668)

